### PR TITLE
Stricter level code validation

### DIFF
--- a/src/app/components/Inputs/LevelcodeInput.tsx
+++ b/src/app/components/Inputs/LevelcodeInput.tsx
@@ -8,8 +8,7 @@ import './styles/LevelcodeInput.css'
 
 function checkLevelCode(levelCode: string) {
 	return levelCode 
-		&& levelCode.length == 9
-		&& levelCode[4] == "-"
+		&& /^[A-Z0-9]{4}\-[A-Z0-9]{4}$/.test(levelCode)
 }
 
 export declare interface ILevelcodeInputProps {

--- a/src/server/routes/API.ts
+++ b/src/server/routes/API.ts
@@ -41,8 +41,7 @@ async function unzipBuffer(buffer: InputType) {
 // Checks that a levelcode is formatted correctly
 function checkLevelCode(levelCode: string) {
 	return levelCode !== undefined
-		&& levelCode.length === 9
-		&& levelCode[4] === "-"
+		&& /^[A-Z0-9]{4}\-[A-Z0-9]{4}$/.test(levelCode)
 }
 
 // Download and decode a file to a buffer from the official server


### PR DESCRIPTION
Uses a regex to match 4 alphanumeric chars, a dash, and another 4 alphanumeric chars

(note that currently level codes can't contain "5", "S", "O" or "0", but older levels can still have that)